### PR TITLE
Fix NPE in xtextspy view on empty content

### DIFF
--- a/com.avaloq.tools.ddk.xtextspy/src/com/avaloq/tools/ddk/xtextspy/XtextElementSelectionListener.java
+++ b/com.avaloq.tools.ddk.xtextspy/src/com/avaloq/tools/ddk/xtextspy/XtextElementSelectionListener.java
@@ -81,7 +81,11 @@ public class XtextElementSelectionListener implements ISelectionListener, ISelec
         @Override
         @SuppressWarnings({"PMD.SignatureDeclareThrowsException"})
         public ILeafNode exec(final XtextResource resource) throws Exception {
-          return NodeModelUtils.findLeafNodeAtOffset(NodeModelUtils.getNode(resource.getContents().get(0)), ((ITextSelection) selection).getOffset());
+          INode node = NodeModelUtils.getNode(resource.getContents().get(0));
+          if (node == null) {
+            return null;
+          }
+          return NodeModelUtils.findLeafNodeAtOffset(node, ((ITextSelection) selection).getOffset());
         }
       });
     }


### PR DESCRIPTION
Opening a source that has no content caused a null pointer exception when the XtextSpy View is open.
Parameter node of NodeModelUtils.findLeafNodeAtOffset must not be null.